### PR TITLE
✏️(profile) add missing timestamp in accessed page template

### DIFF
--- a/statements/accessed_page.md
+++ b/statements/accessed_page.md
@@ -41,7 +41,8 @@ A user has accessed or navigated a page on a LMS or an e-learning platform.
             }
          ]
       }
-   }
+   },
+   "timestamp": "2016-06-09T15:34:26.887Z"
 }
 ```
 


### PR DESCRIPTION
Example of template for "accessed a page" statement was missing a timestamp.

